### PR TITLE
feat: Add support for asm_groups_to_display

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -14,7 +14,7 @@ ParameterLists:
 
 # Increase the max AbcSize
 AbcSize:
-  Max: 34
+  Max: 37
 
 # Increase max number of "/" in %r
 RegexpLiteral:
@@ -26,7 +26,7 @@ ClassLength:
   CountComments: true
 
 CyclomaticComplexity:
-  Max: 11
+  Max: 12
 
 PerceivedComplexity:
-  Max: 11
+  Max: 12

--- a/lib/smtpapi.rb
+++ b/lib/smtpapi.rb
@@ -9,7 +9,8 @@ module Smtpapi
   #
   class Header
     attr_reader :to, :sub, :section, :category, :unique_args, :filters
-    attr_reader :send_at, :send_each_at, :asm_group_id, :ip_pool
+    attr_reader :send_at, :send_each_at, :asm_group_id,
+                :asm_groups_to_display, :ip_pool
 
     def initialize
       @to = []
@@ -21,6 +22,7 @@ module Smtpapi
       @send_at = nil
       @send_each_at = []
       @asm_group_id = nil
+      @asm_groups_to_display = []
       @ip_pool = nil
     end
 
@@ -109,6 +111,16 @@ module Smtpapi
       self
     end
 
+    def add_asm_groups_to_display(group_id)
+      @asm_groups_to_display.push(group_id)
+      self
+    end
+
+    def set_asm_groups_to_display(group_ids)
+      @asm_groups_to_display = group_ids
+      self
+    end
+
     def set_ip_pool(pool_name)
       @ip_pool = pool_name
       self
@@ -125,6 +137,8 @@ module Smtpapi
       data['send_at'] = @send_at.to_i unless @send_at.nil?
       data['asm_group_id'] = @asm_group_id.to_i unless @asm_group_id.nil?
       data['ip_pool'] = @ip_pool unless @ip_pool.nil?
+      data['asm_groups_to_display'] =
+          @asm_groups_to_display if @asm_groups_to_display.length > 0
       str_each_at = []
       @send_each_at.each do |val|
         str_each_at.push(val.to_i)

--- a/test/test.rb
+++ b/test/test.rb
@@ -195,6 +195,21 @@ class SmtpapiTest < Test::Unit::TestCase
     assert_equal('{"asm_group_id":2}', header.json_string)
   end
 
+  def test_add_asm_groups_to_display
+    header = Smtpapi::Header.new
+    header.add_asm_groups_to_display(1)
+    header.add_asm_groups_to_display(2)
+
+    assert_equal('{"asm_groups_to_display":[1,2]}', header.json_string)
+  end
+
+  def test_set_asm_groups_to_display
+    header = Smtpapi::Header.new
+    header.set_asm_groups_to_display([1, 2])
+
+    assert_equal('{"asm_groups_to_display":[1,2]}', header.json_string)
+  end
+
   def test_ip_pool
     header = Smtpapi::Header.new
     header.set_ip_pool('test_pool')


### PR DESCRIPTION
Hi, I want to use `asm_groups_to_display` field (https://sendgrid.com/docs/API_Reference/SMTP_API/suppressions.html) with this library.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/sendgrid/smtpapi-ruby/2)

<!-- Reviewable:end -->
