### PR TITLE
Add support for batch_id

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,14 @@ lt3       = Time.local(2015,  9,  1,  4,  5,  6)
 header.set_send_each_at([lt1, lt2, lt3])
 ```
 
+### set_batch_id
+
+```ruby
+header    = Smtpapi::Header.new
+batch_id = "MWQxZmIyODYtNjE1Ni0xMWU1LWI3ZTUtMDgwMDI3OGJkMmY2LWEzMmViMjYxMw"
+header.set_batch_id(batch_id)
+```
+
 ### asm_group_id
 
 This is to specify an [ASM Group](https://sendgrid.com/docs/User_Guide/advanced_suppression_manager.html) for the message.

--- a/lib/smtpapi.rb
+++ b/lib/smtpapi.rb
@@ -9,7 +9,7 @@ module Smtpapi
   #
   class Header
     attr_reader :to, :sub, :section, :category, :unique_args, :filters
-    attr_reader :send_at, :send_each_at, :asm_group_id, :ip_pool
+    attr_reader :send_at, :send_each_at, :batch_id, :asm_group_id, :ip_pool
 
     def initialize
       @to = []
@@ -19,6 +19,7 @@ module Smtpapi
       @unique_args = {}
       @filters = {}
       @send_at = nil
+      @batch_id = nil
       @send_each_at = []
       @asm_group_id = nil
       @ip_pool = nil
@@ -104,6 +105,11 @@ module Smtpapi
       self
     end
 
+    def set_batch_id(batch_id)
+      @batch_id = batch_id
+      self
+    end
+
     def set_asm_group(group_id)
       @asm_group_id = group_id
       self
@@ -123,6 +129,7 @@ module Smtpapi
       data['category'] = @category if @category.length > 0
       data['filters'] = @filters if @filters.length > 0
       data['send_at'] = @send_at.to_i unless @send_at.nil?
+      data['batch_id'] = @batch_id unless @batch_id.nil?
       data['asm_group_id'] = @asm_group_id.to_i unless @asm_group_id.nil?
       data['ip_pool'] = @ip_pool unless @ip_pool.nil?
       str_each_at = []

--- a/test/test.rb
+++ b/test/test.rb
@@ -188,6 +188,14 @@ class SmtpapiTest < Test::Unit::TestCase
     )
   end
 
+  def test_batch_id
+    header = Smtpapi::Header.new
+    batch_id = "MWQxZmIyODYtNjE1Ni0xMWU1LWI3ZTUtMDgwMDI3OGJkMmY2LWEzMmViMjYxMw"
+    header.set_batch_id(batch_id)
+
+    assert_equal("{\"batch_id\":\"#{batch_id}\"}", header.json_string)
+  end
+
   def test_asm_group_id
     header = Smtpapi::Header.new
     header.set_asm_group(2)


### PR DESCRIPTION
Add support for `batch_id` as documented here: https://sendgrid.com/docs/API_Reference/SMTP_API/scheduling_parameters.html

/cc @eddiezane @thinkingserious
