### PR TITLE
create script for updating changelog

### DIFF
--- a/scripts/release.rb
+++ b/scripts/release.rb
@@ -1,0 +1,69 @@
+#!/usr/bin/env ruby
+
+require 'git'
+require 'net/http'
+require 'json'
+require 'date'
+
+def extract_pull_request_number(commit)
+  commit.message.match('Merge pull request #(\d+) from.*').captures.first
+end
+
+def fetch_pull_request_data(pull_request_number)
+  pull_request = fetch_github_data("https://api.github.com/repos/sendgrid/smtpapi-ruby/pulls/#{pull_request_number}")
+  user_data = fetch_github_data(pull_request['user']['url'])
+
+  { number: pull_request['number'],
+    title: pull_request['title'],
+    user_url: user_data['url'],
+    user_login: user_data['login'],
+    user_name: user_data['name'] }
+end
+
+def fetch_github_data(pull_request_url)
+  uri = URI(pull_request_url)
+  pull_request_response = Net::HTTP.start(uri.hostname, uri.port, use_ssl: uri.scheme == 'https') do |http|
+    req = Net::HTTP::Get.new(uri)
+    req['Accept'] = 'application/vnd.github.v3+json'
+    req['Authorization'] = "token #{ENV['GITHUB_TOKEN']}" if ENV['GITHUB_TOKEN']
+
+    http.request(req)
+  end
+  raise("Response error #{pull_request_response.msg}") unless pull_request_response.is_a?(Net::HTTPSuccess)
+
+  JSON.parse(pull_request_response.body)
+end
+
+def update_changelog(file_path, prs, version_number)
+  prs_entries = prs.map(&method(:changelog_entry))
+  version_header = "## [#{version_number}] - #{Date.today} \n### Added\n"
+
+  replace(file_path, /^##/) { |match| "#{version_header + prs_entries.join("\n")}\n\n#{match}" }
+end
+
+def changelog_entry(pr_data)
+  "- ##{pr_data[:number]} #{pr_data[:title]}\n" \
+  "- Thanks to [#{pr_data[:user_name] || pr_data[:user_login]}](#{pr_data[:user_url]}) for the pull request!"
+end
+
+def replace(file_path, regexp, *args, &block)
+  content = File.read(file_path).sub(regexp, *args, &block)
+  File.open(file_path, 'wb') { |file| file.write(content) }
+end
+
+version_number = ARGV[0] || raise('No version number was passed')
+root_folder = File.expand_path('..', __dir__)
+g = Git.open(root_folder)
+file_path = 'CHANGELOG.md'
+
+last_tag = g.describe(nil, tags: true, abbrev: 0)
+
+merged_pull_requests = g.log.between(last_tag, 'master').grep('Merge pull request')
+
+prs = merged_pull_requests
+        .map(&method(:extract_pull_request_number))
+        .map(&method(:fetch_pull_request_data))
+
+update_changelog(file_path, prs, version_number)
+
+puts "Changelog updated, the new version is #{version_number}"

--- a/smtpapi.gemspec
+++ b/smtpapi.gemspec
@@ -18,6 +18,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_development_dependency 'bundler', '~> 1.5'
+  spec.add_development_dependency 'git', '~> 1.5.0'
   spec.add_development_dependency 'rake'
   spec.add_development_dependency('rubocop', '>=0.29.0', '<0.30.0')
   spec.add_development_dependency('test-unit', '~> 3.0')


### PR DESCRIPTION
Add a ruby script that can be run from root project directory with scripts/release.rb version_number.
The param is the version_number you want to upgrade your changelog.
[Here](https://gist.github.com/Veith3n/9d902c4edf3fffd5e3376481e761f724) is gist of how it looks like after generation of new version with scripts/release.rb 3.3.2
In order to get unlimited queries to Github API provide `GITHUB_TOKEN` as environment variable.
Resolves #75