### PR TITLE
chore: Add test coverage analysis

### DIFF
--- a/smtpapi.gemspec
+++ b/smtpapi.gemspec
@@ -21,4 +21,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rake'
   spec.add_development_dependency('rubocop', '>=0.29.0', '<0.30.0')
   spec.add_development_dependency('test-unit', '~> 3.0')
+  spec.add_development_dependency 'simplecov'
 end

--- a/test/test.rb
+++ b/test/test.rb
@@ -1,3 +1,4 @@
+require 'test_helper'
 require 'test/unit'
 require './lib/smtpapi'
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,0 +1,2 @@
+require 'simplecov'
+SimpleCov.start


### PR DESCRIPTION
### Short description of what this PR does:
As a contributor, I'd like to know what baseline code coverage is and how my enhancements affect it.

No documentation was updated because code coverage is now part of the default `rake test` run, with no further action required.

```
smtpapi-ruby$ rake test

<test debug info>
Coverage report generated for Unit Tests, Unknown Test Framework,
test:units to ../smtpapi-ruby/coverage. 101 / 101 LOC (100.0%) covered.
```

### Checklist
- [X] I have made a material change to the repo (functionality, testing, spelling, grammar)
- [X] I have read the [Contribution Guide] and my PR follows them.
- [X] I updated my branch with the master branch.
- [X] (N/A) I have added tests that prove my fix is effective or that my feature works
- [X] (N/A) I have added necessary documentation about the functionality in the appropriate .md file
- [X] (N/A) I have added in line documentation to the code I modified